### PR TITLE
Add Orion-LD adapter microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ def read_root():
 ### 新增微服务
 - `mysql-adapter`：提供 MySQL 数据库操作 API
 - `minio-adapter`：提供 MinIO 对象存储操作 API
+- `orion-ld-adapter`：提供 Orion-LD 实体管理 API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,18 @@ services:
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=test
 
+  orion-ld-adapter:
+    build:
+      context: ./services/orion-ld-adapter
+    ports:
+      - "8003:8000"
+    depends_on:
+      - orion
+    networks:
+      - default
+    environment:
+      - ORION_URL=http://orion:1026
+
 
 volumes:
   mysql_data:

--- a/services/orion-ld-adapter/Dockerfile
+++ b/services/orion-ld-adapter/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/orion-ld-adapter/app/crud.py
+++ b/services/orion-ld-adapter/app/crud.py
@@ -1,0 +1,34 @@
+from typing import Optional, Dict, Any
+from app.orion_client import session, ORION_URL
+
+
+def create_entity(entity: Dict[str, Any]):
+    resp = session.post(f"{ORION_URL}/ngsi-ld/v1/entities", json=entity)
+    resp.raise_for_status()
+    return entity.get("id")
+
+
+def get_entity(entity_id: str):
+    resp = session.get(f"{ORION_URL}/ngsi-ld/v1/entities/{entity_id}")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def update_entity(entity_id: str, attributes: Dict[str, Any]):
+    resp = session.patch(
+        f"{ORION_URL}/ngsi-ld/v1/entities/{entity_id}/attrs",
+        json=attributes,
+    )
+    resp.raise_for_status()
+
+
+def delete_entity(entity_id: str):
+    resp = session.delete(f"{ORION_URL}/ngsi-ld/v1/entities/{entity_id}")
+    resp.raise_for_status()
+
+
+def list_entities(entity_type: Optional[str] = None):
+    params = {"type": entity_type} if entity_type else None
+    resp = session.get(f"{ORION_URL}/ngsi-ld/v1/entities", params=params)
+    resp.raise_for_status()
+    return resp.json()

--- a/services/orion-ld-adapter/app/main.py
+++ b/services/orion-ld-adapter/app/main.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+from app.routers import entity
+
+app = FastAPI(title="Orion-LD Adapter Service")
+
+app.include_router(entity.router, prefix="/orion/entity", tags=["Entity"])

--- a/services/orion-ld-adapter/app/orion_client.py
+++ b/services/orion-ld-adapter/app/orion_client.py
@@ -1,0 +1,7 @@
+import os
+import requests
+
+ORION_URL = os.getenv("ORION_URL", "http://orion:1026")
+
+session = requests.Session()
+session.headers.update({"Content-Type": "application/ld+json"})

--- a/services/orion-ld-adapter/app/routers/entity.py
+++ b/services/orion-ld-adapter/app/routers/entity.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, HTTPException
+from app.schemas import EntityCreateRequest, EntityUpdateRequest
+from app import crud
+
+router = APIRouter()
+
+
+@router.post("/create")
+def create_entity(req: EntityCreateRequest):
+    try:
+        entity_id = crud.create_entity(req.entity)
+        return {"id": entity_id}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/get")
+def get_entity(entity_id: str):
+    try:
+        entity = crud.get_entity(entity_id)
+        return {"entity": entity}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.patch("/update")
+def update_entity(req: EntityUpdateRequest):
+    try:
+        crud.update_entity(req.entity_id, req.attributes)
+        return {"message": "updated"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/delete")
+def delete_entity(entity_id: str):
+    try:
+        crud.delete_entity(entity_id)
+        return {"message": "deleted"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/list")
+def list_entities(entity_type: str = None):
+    try:
+        entities = crud.list_entities(entity_type)
+        return {"entities": entities}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/services/orion-ld-adapter/app/schemas.py
+++ b/services/orion-ld-adapter/app/schemas.py
@@ -1,0 +1,11 @@
+from typing import Dict, Any
+from pydantic import BaseModel
+
+
+class EntityCreateRequest(BaseModel):
+    entity: Dict[str, Any]
+
+
+class EntityUpdateRequest(BaseModel):
+    entity_id: str
+    attributes: Dict[str, Any]

--- a/services/orion-ld-adapter/postman/orion_ld_adapter_collection.json
+++ b/services/orion-ld-adapter/postman/orion_ld_adapter_collection.json
@@ -1,0 +1,135 @@
+{
+  "info": {
+    "_postman_id": "abcd1234-5678-90ab-cdef-1234567890ab",
+    "name": "Orion-LD Adapter API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://8.130.150.104:8003" }
+  ],
+  "item": [
+    {
+      "name": "Create Entity",
+      "request": {
+        "method": "POST",
+        "header": [ { "key": "Content-Type", "value": "application/json" } ],
+        "url": {
+          "raw": "{{baseUrl}}/orion/entity/create",
+          "host": [ "{{baseUrl}}" ],
+          "path": [ "orion", "entity", "create" ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"entity\": {\n    \"id\": \"urn:ngsi-ld:Device:001\",\n    \"type\": \"Device\",\n    \"temperature\": {\"type\": \"Property\", \"value\": 21}\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Get Entity",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/orion/entity/get?entity_id=urn:ngsi-ld:Device:001",
+          "host": [ "{{baseUrl}}" ],
+          "path": [ "orion", "entity", "get" ],
+          "query": [ { "key": "entity_id", "value": "urn:ngsi-ld:Device:001" } ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Update Entity",
+      "request": {
+        "method": "PATCH",
+        "header": [ { "key": "Content-Type", "value": "application/json" } ],
+        "url": {
+          "raw": "{{baseUrl}}/orion/entity/update",
+          "host": [ "{{baseUrl}}" ],
+          "path": [ "orion", "entity", "update" ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"entity_id\": \"urn:ngsi-ld:Device:001\",\n  \"attributes\": {\n    \"temperature\": {\"type\": \"Property\", \"value\": 22}\n  }\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "List Entities",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/orion/entity/list?type=Device",
+          "host": [ "{{baseUrl}}" ],
+          "path": [ "orion", "entity", "list" ],
+          "query": [ { "key": "type", "value": "Device" } ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Delete Entity",
+      "request": {
+        "method": "DELETE",
+        "url": {
+          "raw": "{{baseUrl}}/orion/entity/delete?entity_id=urn:ngsi-ld:Device:001",
+          "host": [ "{{baseUrl}}" ],
+          "path": [ "orion", "entity", "delete" ],
+          "query": [ { "key": "entity_id", "value": "urn:ngsi-ld:Device:001" } ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/services/orion-ld-adapter/requirements.txt
+++ b/services/orion-ld-adapter/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+requests


### PR DESCRIPTION
## Summary
- add Orion-LD adapter service mirroring existing adapter layout
- integrate new service into docker-compose
- document the new microservice in README
- provide Postman collection for testing

## Testing
- `python -m py_compile services/orion-ld-adapter/app/*.py services/orion-ld-adapter/app/routers/*.py`